### PR TITLE
3.0.0: save 0.8 bytes of memory at the cost of 20% code readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bf | bf.h
 `,` | `GET·`
 
 The middle-dot character `·` represents whitespace.
-All programs must be terminated with a `·RET` instruction.
+All programs must be terminated with an extra `·JZR` instruction.
 
 ## Usage
 After a file is converted, the macros described in

--- a/brainfuck.h
+++ b/brainfuck.h
@@ -1,4 +1,4 @@
-/* brainfuck.h 2.0.0 - build brainfuck in a C compiler (not recommended though)
+/* brainfuck.h 3.0.0 - build brainfuck in a C compiler (not recommended though)
  * By unsubtract, MIT license, see README.md */
 #ifndef BRAINFUCK_H
 #define BRAINFUCK_H 2

--- a/brainfuck.h
+++ b/brainfuck.h
@@ -70,8 +70,6 @@
   #error "Invalid EOF format (must be 0, -1 or 1)"
 #endif /* */
 
-#define RET return EXIT_SUCCESS; }
-
 
 /* inserts main function */
 int main(void) {

--- a/brainfuck.h
+++ b/brainfuck.h
@@ -1,7 +1,7 @@
 /* brainfuck.h 3.0.0 - build brainfuck in a C compiler (not recommended though)
  * By unsubtract, MIT license, see README.md */
 #ifndef BRAINFUCK_H
-#define BRAINFUCK_H 2
+#define BRAINFUCK_H 3
 
 #include <stdint.h>
 #include <stdio.h>

--- a/mkbfhsrc.c
+++ b/mkbfhsrc.c
@@ -1,4 +1,4 @@
-/* mkbfhsrc.c 2.0.0 - convert brainfuck sources into brainfuck.h
+/* mkbfhsrc.c 3.0.0 - convert brainfuck sources into brainfuck.h
  * By unsubtract, MIT license, see README.md */
 #include <errno.h>
 #include <stdio.h>
@@ -77,7 +77,7 @@ static void convert(
         case ',': fputs("GET ", outf); break;
         }
     }
-    fputs("RET\n", outf);
+    fputs("JZR\n", outf);
 }
 
 static void pexit(const char *s)


### PR DESCRIPTION
`RET` was behaving as a redundant `JZR` instruction, so it has been removed.